### PR TITLE
FISH-12112 Fix an issue with debugger attaching to wrong maven process

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-payara-micro-intellij
+payara-intellij

--- a/build.gradle
+++ b/build.gradle
@@ -51,14 +51,14 @@ runIde {
 }
 
 intellij {
-    version = '251.26927.53'
+    version = '2025.2.3'
     type = 'IC'
     pluginName = 'Payara IntelliJ Tools'
-    plugins = ['java', 'maven', 'maven-model', 'gradle', 'terminal']
+    plugins = ['java', 'maven', 'gradle', 'terminal']
 }
 
 patchPluginXml {
-    sinceBuild = "251.26927"
+    sinceBuild = "252.13776"
 }
 
 publishPlugin {

--- a/src/main/java/fish/payara/micro/maven/MicroMavenConfiguration.java
+++ b/src/main/java/fish/payara/micro/maven/MicroMavenConfiguration.java
@@ -16,14 +16,19 @@
  */
 package fish.payara.micro.maven;
 
+import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.JavaParameters;
 import com.intellij.execution.configurations.RemoteConnectionCreator;
 import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.idea.maven.execution.MavenRunConfiguration;
 import org.jetbrains.idea.maven.execution.MavenRunnerParameters;
+import org.jetbrains.idea.maven.execution.run.MavenCommandLineState;
 
 public class MicroMavenConfiguration extends MavenRunConfiguration {
 
@@ -69,4 +74,8 @@ public class MicroMavenConfiguration extends MavenRunConfiguration {
         return new MicroMavenRemoteConnectionCreator(javaParameters, this);
     }
 
+    @Override
+    public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) {
+        return new MavenCommandLineState(env, this);
+    }
 }

--- a/src/main/java/fish/payara/server/maven/ServerMavenConfiguration.java
+++ b/src/main/java/fish/payara/server/maven/ServerMavenConfiguration.java
@@ -16,10 +16,13 @@
  */
 package fish.payara.server.maven;
 
+import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.JavaParameters;
 import com.intellij.execution.configurations.RemoteConnectionCreator;
 import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import static fish.payara.PayaraConstants.DEFAULT_DEBUG_PORT;
@@ -29,6 +32,7 @@ import org.jetbrains.idea.maven.execution.MavenRunConfiguration;
 import org.jetbrains.idea.maven.execution.MavenRunnerParameters;
 import org.jetbrains.annotations.NotNull;
 import org.jdom.Element;
+import org.jetbrains.idea.maven.execution.run.MavenCommandLineState;
 
 public class ServerMavenConfiguration extends MavenRunConfiguration {
 
@@ -373,4 +377,8 @@ public class ServerMavenConfiguration extends MavenRunConfiguration {
         return new ServerMavenRemoteConnectionCreator(javaParameters, this);
     }
 
+    @Override
+    public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) {
+        return new MavenCommandLineState(env, this);
+    }
 }


### PR DESCRIPTION
Fixes a bug where the IDE attaches the debug agent to the maven wrapper process rather than the Payara micro/server processes

Also bumped sandbox to latest version at time: 2025.2.3